### PR TITLE
Fix Issue #3306

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -84,6 +84,6 @@ export const IS_SAFARI = (/Safari/i).test(USER_AGENT) && !IS_CHROME && !IS_ANDRO
 export const IS_ANY_SAFARI = (IS_SAFARI || IS_IOS) && !IS_CHROME;
 
 export const TOUCH_ENABLED = Dom.isReal() && (
-  'ontouchstart' in window ||
-  window.DocumentTouch &&
-  window.document instanceof window.DocumentTouch);
+  'ontouchstart' in window || 
+  window.navigator.maxTouchPoints || 
+  window.DocumentTouch && document instanceof window.DocumentTouch);


### PR DESCRIPTION
Change TOUCH_ENABLE Initialization

## Description
Fixed the Issue with the code proposed


## Specific Changes proposed
Changed the TOUCH_ENABLE constant initalization 
Now evaluate true with Windows 10 with touch screen and Browser: Chrome 50 and IE11, Edge and also with Windows Phone 10 and Edge.
With a Windows 10 computer without touch screen it evaluate false as it should.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/axedog/edit?html,output))
- [ ] Reviewed by Two Core Contributors
